### PR TITLE
feat: 状态栏增加 Git 分支显示、始终显示费用、修复启动崩溃

### DIFF
--- a/src/hooks.py
+++ b/src/hooks.py
@@ -10,7 +10,7 @@ CLAUDE_SETTINGS = os.path.expanduser("~/.claude/settings.json")
 HOOK_SCRIPT_PATH = os.path.expanduser("~/.claude/tt-statusline.py")
 CODEX_CONFIG = os.path.expanduser("~/.codex/config.toml")
 CODEX_BACKUP = os.path.expanduser("~/.codex/tt-backup.json")
-HOOK_VERSION = "1.1"
+HOOK_VERSION = "1.2"
 _BACKUP_KEY = "tokenTracker"
 _PREV_SL_KEY = "previousStatusLine"
 _SL_REGEX = re.compile(r'status_line\s*=\s*\[.*?\]', re.DOTALL)
@@ -25,8 +25,8 @@ CODEX_STATUS_LINE = [
 
 HOOK_SCRIPT = r'''#!/usr/bin/env python3
 """Claude Code statusLine — 状态栏显示 + 数据持久化到 tt-status.json"""
-__version__ = "1.1"
-import json, os, sys, tempfile
+__version__ = "1.2"
+import json, os, subprocess, sys, tempfile
 from datetime import datetime, timezone
 
 STATUS_FILE = os.path.expanduser("~/.claude/tt-status.json")
@@ -57,6 +57,29 @@ def progress_bar(value):
     return f"{color_by_pct(pct)}{filled_char * filled}{C['reset']}{empty_char * (width - filled)} {pct:.0f}%"
 
 
+def git_status(cwd):
+    if not cwd or not os.path.isdir(os.path.join(cwd, ".git")):
+        return ""
+    try:
+        branch = subprocess.check_output(
+            ["git", "branch", "--show-current"], cwd=cwd,
+            stderr=subprocess.DEVNULL, text=True, timeout=2,
+        ).strip()
+    except Exception:
+        return ""
+    dirty = ""
+    try:
+        porcelain = subprocess.check_output(
+            ["git", "status", "--porcelain", "--untracked-files=no"], cwd=cwd,
+            stderr=subprocess.DEVNULL, text=True, timeout=2,
+        ).strip()
+        if porcelain:
+            dirty = "*"
+    except Exception:
+        pass
+    return f"{C['magenta']}{branch}{dirty}{C['reset']}" if branch else ""
+
+
 def save_data(data):
     data["_received_at"] = datetime.now(timezone.utc).isoformat()
     try:
@@ -71,24 +94,30 @@ def save_data(data):
 def render(data):
     parts = []
 
+    # Project + Git
     project = data.get("workspace", {}).get("project_dir", "")
     if project:
-        parts.append(f"{C['cyan']}{os.path.basename(project)}{C['reset']}")
+        name = os.path.basename(project)
+        gs = git_status(data.get("workspace", {}).get("current_dir", project))
+        if gs:
+            parts.append(f"{C['cyan']}{name}{C['reset']} git:({gs})")
+        else:
+            parts.append(f"{C['cyan']}{name}{C['reset']}")
 
+    # Rate limits
     rl = data.get("rate_limits", {})
-    has_rl = False
     for key, label in [("five_hour", "5h"), ("seven_day", "7d")]:
         pct = rl.get(key, {}).get("used_percentage")
         if pct is not None:
-            has_rl = True
             parts.append(f"{C['blue']}{label}:{C['reset']}{progress_bar(pct)}")
 
-    if not has_rl:
-        cost = data.get("cost", {})
-        usd = cost.get("total_cost_usd")
-        if usd is not None:
-            parts.append(f"{C['blue']}Cost:{C['reset']}{C['peach']}${usd:.2f}{C['reset']}")
+    # Cost (always show if available)
+    cost = data.get("cost", {})
+    usd = cost.get("total_cost_usd")
+    if usd is not None:
+        parts.append(f"{C['blue']}Cost:{C['reset']}{C['peach']}${usd:.2f}{C['reset']}")
 
+    # Context
     ctx = data.get("context_window", {})
     if ctx.get("used_percentage") is not None:
         size = ctx.get("context_window_size", 0)
@@ -98,10 +127,11 @@ def render(data):
 
     total_in = ctx.get("total_input_tokens", 0)
     total_out = ctx.get("total_output_tokens", 0)
-    cache = ctx.get("current_usage", {}).get("cache_read_input_tokens", 0)
+    cache = (ctx.get("current_usage") or {}).get("cache_read_input_tokens", 0)
     if total_in or total_out:
         parts.append(f"{C['peach']}Tokens: {fmt_tokens(total_in)}↑ {fmt_tokens(total_out)}↓ cached:{fmt_tokens(cache)}{C['reset']}")
 
+    # Model
     model_name = data.get("model", {}).get("display_name", "")
     if model_name:
         effort = data.get("effort", {}).get("level", "")
@@ -232,7 +262,7 @@ def _setup_claude() -> None:
         console.print(f"[yellow]检测到已有 statusLine，备份后替换[/yellow]")
         settings.setdefault(_BACKUP_KEY, {})[_PREV_SL_KEY] = existing
 
-    settings["statusLine"] = {"type": "command", "command": HOOK_SCRIPT_PATH}
+    settings["statusLine"] = {"type": "command", "command": HOOK_SCRIPT_PATH, "refreshInterval": 5}
 
     with open(CLAUDE_SETTINGS, "w", encoding="utf-8") as f:
         json.dump(settings, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## 新功能

### 1. Git 分支状态

状态栏显示当前 Git 分支名和 dirty 标记：

```
token-tracker git:(main*) | 5h:██░░░░░░ 24% | 7d:███░░░░░ 41% | Cost:$5.38 | 1.0M CTX: 12% | Tokens: 116k↑ 383↓ cached:116k | mimo-v2.5-pro[1m]
```

- `git branch --show-current` 获取分支名
- `git status --porcelain` 检测未提交修改（`*` 标记）
- 2 秒超时，非 git 目录自动降级不显示

### 2. 始终显示费用

之前只在无 rate_limits 时才显示 Cost，现在有数据就始终显示，rate_limits 和 Cost 同时可见。

### 3. 启动修复

- 修复 `current_usage: null` 导致的启动崩溃（同 PR #2）
- setup 模板增加 `refreshInterval: 5`

## 改动

- `src/hooks.py`: 新增 `git_status()` 函数，更新 `render()` 逻辑，版本升级 1.1 → 1.2

🤖 Generated with [Claude Code](https://claude.ai/code)