### PR TITLE
fix: Windows compatibility for statusline hook

### DIFF
--- a/src/hooks.py
+++ b/src/hooks.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import stat
+import sys
 import tomllib
 
 from .ui.tables import console
@@ -37,6 +38,10 @@ C = {
     "peach": "\033[38;5;216m", "dim": "\033[2m", "reset": "\033[0m",
 }
 
+# Windows GBK workaround
+if sys.platform == 'win32':
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+
 
 def vlen(s):
     return len(ANSI_RE.sub("", s))
@@ -47,8 +52,8 @@ def get_width():
         return max(1, os.get_terminal_size(2).columns - 4)
     except Exception:
         pass
-    import fcntl, struct, termios
     try:
+        import fcntl, struct, termios
         with open('/dev/tty', 'r') as tty:
             res = fcntl.ioctl(tty, termios.TIOCGWINSZ, b'\x00' * 8)
             return max(1, struct.unpack('hh', res[:4])[1] - 4)
@@ -237,6 +242,7 @@ def render(data, now):
     output = [" | ".join(line) for line in (line1, line2, line3) if line]
     if output:
         print("\n".join(output))
+        sys.stdout.flush()
 
 
 def main():
@@ -363,6 +369,8 @@ def _setup_claude() -> None:
         settings.setdefault(_BACKUP_KEY, {})[_PREV_SL_KEY] = existing
 
     settings["statusLine"] = {"type": "command", "command": f"python3 {HOOK_SCRIPT_PATH}"}
+    if sys.platform == 'win32':
+        settings["statusLine"]["command"] = f"{sys.executable} {HOOK_SCRIPT_PATH}"
 
     with open(CLAUDE_SETTINGS, "w", encoding="utf-8") as f:
         json.dump(settings, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
## 问题
Windows 环境下 `tt setup` 配置后状态栏不显示，Fixes #6

## 根因
4 个 Windows 兼容性问题叠加导致：

1. **`python3` 命令不存在** — Windows 上 `python3` 指向 Microsoft Store 占位程序，使用 `sys.executable` 获取当前 Python 路径
2. **`import fcntl` 在 try 块外** — fcntl 是 Unix 专有模块，移入 try 块内避免 ModuleNotFoundError
3. **GBK 编码无法输出 Unicode** — 进度条字符 `█░` 不在 GBK 字符集中，Win32 下强制 stdout 为 UTF-8
4. **管道 stdout 缓冲** — `print()` 后加 `sys.stdout.flush()` 确保输出被 Claude Code 及时捕获

## 测试
在 Windows 10 + Git Bash 环境下手动测试通过，状态栏三行正常显示。