### PR TITLE
Handle non-object Codex JSONL rows

### DIFF
--- a/src/adapters/codex.py
+++ b/src/adapters/codex.py
@@ -82,6 +82,8 @@ def _extract_rate_limits(path: Path, models: dict[str, str]) -> RateLimits | Non
                     data = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                if not isinstance(data, dict):
+                    continue
                 if data.get("type") == "session_meta":
                     session_id = data.get("payload", {}).get("id", "")
                 if data.get("type") != "event_msg":
@@ -161,6 +163,8 @@ def _parse_jsonl(
                 try:
                     data = json.loads(line)
                 except json.JSONDecodeError:
+                    continue
+                if not isinstance(data, dict):
                     continue
 
                 row_type = data.get("type")


### PR DESCRIPTION
## Summary
- Skip Codex session lines that decode to non-object JSON values before calling `.get()`
- Apply the same guard to rate-limit extraction so malformed/non-standard JSONL fragments do not crash Codex loading

## Why
Some Codex session files can contain valid JSON values that are not objects, such as standalone strings from pretty-printed fragments. The current parser assumes every decoded line is a dict and crashes with `AttributeError: 'str' object has no attribute 'get'`.

## Validation
- `python3 -m compileall -q src`
- `PYTHONPATH=. /Users/mrzz/.local/share/uv/tools/token-tracker/bin/python -m src.cli codex`