### PR TITLE
feat: 支持第三方 Coding Plan 配额对接

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ AGENTS.md
 CLAUDE.md
 pricing_cache.json
 docs/
+uv.lock

--- a/README.md
+++ b/README.md
@@ -214,6 +214,92 @@ if __name__ == "__main__":
     main()
 ```
 
+### opencode 配置样例
+
+opencode 的用量数据不是独立 REST API，而是内嵌在 workspace 页面 HTML 的 inline script 里（SolidJS hydration stream），结构为 `rollingUsage` / `weeklyUsage` / `monthlyUsage`。鉴权用登录后的 `auth` cookie，脚本 GET 页面后再用正则抠出三项用量。
+
+创建 `~/.claude/tt-opencode-quota.py`：
+
+```python
+#!/usr/bin/env python3
+"""opencode 用量查询脚本：GET workspace 页面 HTML，正则抠出 inline script 的三项用量。"""
+import json
+import re
+import time
+import urllib.request
+import urllib.error
+import ssl
+import sys
+
+# ========== 配置区域 ==========
+# 工作区 ID（URL 里的 wrk_xxx）
+WORKSPACE_ID = "wrk_xxxxxxxxxxxxxxxxxxxxxxxx"
+
+# 从浏览器复制 auth cookie 的值（Fe26.2**... 那一长串），会过期需定期覆盖
+AUTH_COOKIE = "Fe26.2**xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+PAGE_URL = f"https://opencode.ai/workspace/{WORKSPACE_ID}/go"
+# =============================
+
+
+def fetch_usage():
+    req = urllib.request.Request(PAGE_URL, method="GET")
+    req.add_header("cookie", f"oc_locale=zh; auth={AUTH_COOKIE.strip()}")
+    req.add_header("user-agent",
+                   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                   "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36")
+    ssl_context = ssl.create_default_context()
+    ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.CERT_NONE
+    with urllib.request.urlopen(req, timeout=15, context=ssl_context) as resp:
+        return resp.read().decode()
+
+
+def parse(html):
+    """hydration 流里顺序固定为 rollingUsage -> weeklyUsage -> monthlyUsage。"""
+    secs = re.findall(r"resetInSec:(\d+)", html)
+    pcts = re.findall(r"usagePercent:([\d.]+)", html)
+    if len(secs) < 3 or len(pcts) < 3:
+        raise ValueError("用量字段解析失败，cookie 可能已过期或页面结构变化")
+    return secs[:3], pcts[:3]
+
+
+def main():
+    now = int(time.time())
+    try:
+        html = fetch_usage()
+        secs, pcts = parse(html)
+        rolling_sec, weekly_sec, monthly_sec = (int(s) for s in secs)
+        rolling_pct, weekly_pct, monthly_pct = (float(p) for p in pcts)
+        print(json.dumps({
+            "five_hour": {"used_percentage": round(rolling_pct, 1), "resets_at": now + rolling_sec},
+            "seven_day": {"used_percentage": round(weekly_pct, 1), "resets_at": now + weekly_sec},
+            "monthly": {"used_percentage": round(monthly_pct, 1), "resets_at": now + monthly_sec},
+            "source": "opencode",
+        }, ensure_ascii=False))
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+对应的 `tt-config.json`：
+
+```json
+{
+  "rate_provider": {
+    "type": "script",
+    "command": "python ~/.claude/tt-opencode-quota.py",
+    "cache_ttl": 60
+  }
+}
+```
+
+> 注意：`auth` cookie 是 Fe26.2 加密、会过期，失效后需重新从浏览器复制覆盖。
+
 ### 诊断命令
 
 配置完成后，使用诊断命令验证：

--- a/README.md
+++ b/README.md
@@ -114,6 +114,115 @@ tt sessions --sort tokens --asc # 按 token 升序
 | `+` / `-` | 调整会话显示条数（±10，最少 10 条） |
 | `q` | 退出 |
 
+## 第三方 Coding Plan 配额对接
+
+官方 API 会自动注入配额数据到状态栏，但第三方平台（如火山方舟）不支持此机制。Token Tracker 提供可扩展的 Provider 架构，通过脚本或 API 对接第三方平台的 Coding Plan 用量数据。
+
+### 配置方式
+
+在 `~/.claude/tt-config.json` 中配置配额提供者：
+
+```json
+{
+  "rate_provider": {
+    "type": "script",
+    "command": "python ~/.claude/tt-ark-quota.py",
+    "cache_ttl": 60,
+    "timeout": 10
+  }
+}
+```
+
+配置项说明：
+
+| 字段 | 默认值 | 说明 |
+|------|--------|------|
+| `type` | — | 固定为 `script` |
+| `command` | — | 要执行的命令 |
+| `cache_ttl` | `60` | 缓存秒数，避免频繁调用脚本（建议 ≥ 30） |
+| `timeout` | `10` | 脚本执行超时秒数 |
+
+### 脚本输出格式
+
+自定义脚本需要输出标准 JSON 格式：
+
+```json
+{
+  "five_hour": {
+    "used_percentage": 31.5,
+    "resets_at": 1718457600
+  },
+  "seven_day": {
+    "used_percentage": 12.3,
+    "resets_at": 1718889600
+  },
+  "monthly": {
+    "used_percentage": 8.7,
+    "resets_at": 1719753600
+  },
+  "source": "火山方舟"
+}
+```
+
+### 火山方舟配置样例
+
+创建 `~/.claude/tt-ark-quota.py`：
+
+```python
+#!/usr/bin/env python3
+import json
+import urllib.request
+import urllib.error
+import sys
+
+# 从浏览器开发者工具复制 Cookie 和 x-csrf-token
+COOKIE = "monitor_huoshan_web_id=xxx; connect.sid=xxx; ..."
+X_CSRF_TOKEN = "xxx"
+
+API_URL = "https://console.volcengine.com/api/top/ark/cn-beijing/2024-01-01/GetCodingPlanUsage?"
+
+def main():
+    try:
+        req = urllib.request.Request(API_URL, method="POST")
+        req.add_header("cookie", COOKIE)
+        req.add_header("x-csrf-token", X_CSRF_TOKEN)
+
+        with urllib.request.urlopen(req, data=b"{}", timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+
+        quota_map = {}
+        for item in data.get("Result", {}).get("QuotaUsage", []):
+            level = item.get("Level")
+            percent = item.get("Percent")
+            reset = item.get("ResetTimestamp")
+            if level == "session":
+                quota_map["five_hour"] = {"used_percentage": percent, "resets_at": reset}
+            elif level == "weekly":
+                quota_map["seven_day"] = {"used_percentage": percent, "resets_at": reset}
+            elif level == "monthly":
+                quota_map["monthly"] = {"used_percentage": percent, "resets_at": reset}
+
+        print(json.dumps({**quota_map, "source": "火山方舟"}))
+    except urllib.error.HTTPError as e:
+        print(f"HTTP Error: {e.code}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+```
+
+### 诊断命令
+
+配置完成后，使用诊断命令验证：
+
+```bash
+tt quota           # 查看配额状态和提供者信息
+tt quota --debug   # 详细调试信息（含配置内容）
+```
+
 ## 数据来源
 
 | Agent | 路径 | 格式 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -214,6 +214,92 @@ if __name__ == "__main__":
     main()
 ```
 
+### opencode Example
+
+opencode's usage data isn't a standalone REST API — it's embedded in the workspace page HTML as an inline script (SolidJS hydration stream), exposing `rollingUsage` / `weeklyUsage` / `monthlyUsage`. Auth uses the `auth` cookie set after login; the script fetches the page and extracts the three usage entries via regex.
+
+Create `~/.claude/tt-opencode-quota.py`:
+
+```python
+#!/usr/bin/env python3
+"""opencode usage query: fetch the workspace page HTML and extract inline-script usage entries."""
+import json
+import re
+import time
+import urllib.request
+import urllib.error
+import ssl
+import sys
+
+# ========== Config ==========
+# Workspace ID (the wrk_xxx from the URL)
+WORKSPACE_ID = "wrk_xxxxxxxxxxxxxxxxxxxxxxxx"
+
+# Copy the auth cookie value from your browser (the long Fe26.2**... string); it expires, refresh as needed
+AUTH_COOKIE = "Fe26.2**xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+PAGE_URL = f"https://opencode.ai/workspace/{WORKSPACE_ID}/go"
+# =============================
+
+
+def fetch_usage():
+    req = urllib.request.Request(PAGE_URL, method="GET")
+    req.add_header("cookie", f"oc_locale=zh; auth={AUTH_COOKIE.strip()}")
+    req.add_header("user-agent",
+                   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                   "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36")
+    ssl_context = ssl.create_default_context()
+    ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.CERT_NONE
+    with urllib.request.urlopen(req, timeout=15, context=ssl_context) as resp:
+        return resp.read().decode()
+
+
+def parse(html):
+    """In the hydration stream the order is fixed: rollingUsage -> weeklyUsage -> monthlyUsage."""
+    secs = re.findall(r"resetInSec:(\d+)", html)
+    pcts = re.findall(r"usagePercent:([\d.]+)", html)
+    if len(secs) < 3 or len(pcts) < 3:
+        raise ValueError("usage field parsing failed: cookie may be expired or page structure changed")
+    return secs[:3], pcts[:3]
+
+
+def main():
+    now = int(time.time())
+    try:
+        html = fetch_usage()
+        secs, pcts = parse(html)
+        rolling_sec, weekly_sec, monthly_sec = (int(s) for s in secs)
+        rolling_pct, weekly_pct, monthly_pct = (float(p) for p in pcts)
+        print(json.dumps({
+            "five_hour": {"used_percentage": round(rolling_pct, 1), "resets_at": now + rolling_sec},
+            "seven_day": {"used_percentage": round(weekly_pct, 1), "resets_at": now + weekly_sec},
+            "monthly": {"used_percentage": round(monthly_pct, 1), "resets_at": now + monthly_sec},
+            "source": "opencode",
+        }, ensure_ascii=False))
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+The matching `tt-config.json`:
+
+```json
+{
+  "rate_provider": {
+    "type": "script",
+    "command": "python ~/.claude/tt-opencode-quota.py",
+    "cache_ttl": 60
+  }
+}
+```
+
+> Note: the `auth` cookie is Fe26.2-encrypted and expires; re-copy it from your browser when it stops working.
+
 ### Diagnostic Commands
 
 After configuration, use diagnostic commands to verify:

--- a/README_EN.md
+++ b/README_EN.md
@@ -114,6 +114,115 @@ Available sort fields: `tokens` / `cost` / `messages` / `time` / `input` / `outp
 | `+` / `-` | Adjust session count (±10, min 10) |
 | `q` | Quit |
 
+## Third-Party Coding Plan Quota Integration
+
+Official APIs automatically inject quota data into the status line, but third-party platforms (like Volcano Engine Ark) don't support this. Token Tracker provides an extensible Provider architecture to fetch Coding Plan usage data via scripts or APIs.
+
+### Configuration
+
+Configure the quota provider in `~/.claude/tt-config.json`:
+
+```json
+{
+  "rate_provider": {
+    "type": "script",
+    "command": "python ~/.claude/tt-ark-quota.py",
+    "cache_ttl": 60,
+    "timeout": 10
+  }
+}
+```
+
+Configuration options:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `type` | — | Must be `script` |
+| `command` | — | Command to execute |
+| `cache_ttl` | `60` | Cache duration in seconds to avoid frequent script calls (recommended ≥ 30) |
+| `timeout` | `10` | Script execution timeout in seconds |
+
+### Script Output Format
+
+Custom scripts must output standard JSON format:
+
+```json
+{
+  "five_hour": {
+    "used_percentage": 31.5,
+    "resets_at": 1718457600
+  },
+  "seven_day": {
+    "used_percentage": 12.3,
+    "resets_at": 1718889600
+  },
+  "monthly": {
+    "used_percentage": 8.7,
+    "resets_at": 1719753600
+  },
+  "source": "Volcano Engine Ark"
+}
+```
+
+### Volcano Engine Ark Example
+
+Create `~/.claude/tt-ark-quota.py`:
+
+```python
+#!/usr/bin/env python3
+import json
+import urllib.request
+import urllib.error
+import sys
+
+# Copy Cookie and x-csrf-token from browser developer tools
+COOKIE = "monitor_huoshan_web_id=xxx; connect.sid=xxx; ..."
+X_CSRF_TOKEN = "xxx"
+
+API_URL = "https://console.volcengine.com/api/top/ark/cn-beijing/2024-01-01/GetCodingPlanUsage?"
+
+def main():
+    try:
+        req = urllib.request.Request(API_URL, method="POST")
+        req.add_header("cookie", COOKIE)
+        req.add_header("x-csrf-token", X_CSRF_TOKEN)
+
+        with urllib.request.urlopen(req, data=b"{}", timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+
+        quota_map = {}
+        for item in data.get("Result", {}).get("QuotaUsage", []):
+            level = item.get("Level")
+            percent = item.get("Percent")
+            reset = item.get("ResetTimestamp")
+            if level == "session":
+                quota_map["five_hour"] = {"used_percentage": percent, "resets_at": reset}
+            elif level == "weekly":
+                quota_map["seven_day"] = {"used_percentage": percent, "resets_at": reset}
+            elif level == "monthly":
+                quota_map["monthly"] = {"used_percentage": percent, "resets_at": reset}
+
+        print(json.dumps({**quota_map, "source": "Volcano Engine Ark"}))
+    except urllib.error.HTTPError as e:
+        print(f"HTTP Error: {e.code}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()
+```
+
+### Diagnostic Commands
+
+After configuration, use diagnostic commands to verify:
+
+```bash
+tt quota           # show quota status and provider info
+tt quota --debug   # detailed debug output (including configuration)
+```
+
 ## Data Sources
 
 | Agent | Path | Format |

--- a/src/token_tracker/adapters/providers/__init__.py
+++ b/src/token_tracker/adapters/providers/__init__.py
@@ -1,0 +1,20 @@
+from .base import (
+    RateProvider,
+    ProviderRateData,
+    register_provider,
+    create_provider,
+    get_cached_data,
+    set_cached_data,
+)
+
+# 预导入所有 provider 模块，触发 @register_provider 装饰器执行
+from . import script
+
+__all__ = [
+    "RateProvider",
+    "ProviderRateData",
+    "register_provider",
+    "create_provider",
+    "get_cached_data",
+    "set_cached_data",
+]

--- a/src/token_tracker/adapters/providers/base.py
+++ b/src/token_tracker/adapters/providers/base.py
@@ -1,0 +1,89 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+import json
+import hashlib
+import time
+from pathlib import Path
+
+
+@dataclass
+class ProviderRateData:
+    """统一的配额数据格式，所有提供者都输出此格式"""
+    five_hour_pct: float | None = None
+    five_hour_resets_at: int | None = None
+    seven_day_pct: float | None = None
+    seven_day_resets_at: int | None = None
+    monthly_pct: float | None = None
+    monthly_resets_at: int | None = None
+    source: str = ""
+
+
+class RateProvider(ABC):
+    """配额提供者抽象基类"""
+
+    @abstractmethod
+    def get_limits(self) -> ProviderRateData | None:
+        """获取配额数据，失败返回 None"""
+        pass
+
+    @classmethod
+    @abstractmethod
+    def from_config(cls, config: dict) -> "RateProvider":
+        """从配置字典创建提供者实例"""
+        pass
+
+    def _cache_key(self) -> str:
+        """生成缓存键，默认基于类名和配置哈希"""
+        config_str = json.dumps(self.__dict__, sort_keys=True)
+        return f"{self.__class__.__name__}:{hashlib.md5(config_str.encode()).hexdigest()[:8]}"
+
+
+_provider_registry: dict[str, type[RateProvider]] = {}
+
+
+def register_provider(type_name: str):
+    """提供者注册装饰器"""
+    def decorator(cls: type[RateProvider]) -> type[RateProvider]:
+        _provider_registry[type_name] = cls
+        return cls
+    return decorator
+
+
+def create_provider(config: dict) -> RateProvider | None:
+    """根据配置创建提供者实例"""
+    provider_type = config.get("type")
+    if not provider_type or provider_type not in _provider_registry:
+        return None
+    return _provider_registry[provider_type].from_config(config)
+
+
+def get_cache_dir() -> Path:
+    """获取缓存目录"""
+    return Path.home() / ".cache" / "token-tracker"
+
+
+def get_cached_data(cache_key: str, ttl_seconds: int) -> dict | None:
+    """读取缓存数据"""
+    cache_file = get_cache_dir() / f"quota_{cache_key}.json"
+    if not cache_file.exists():
+        return None
+    try:
+        with open(cache_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if time.time() - data.get("_timestamp", 0) < ttl_seconds:
+            return data.get("payload")
+    except (json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
+def set_cached_data(cache_key: str, payload: dict) -> None:
+    """写入缓存数据"""
+    cache_dir = get_cache_dir()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_file = cache_dir / f"quota_{cache_key}.json"
+    try:
+        with open(cache_file, "w", encoding="utf-8") as f:
+            json.dump({"_timestamp": time.time(), "payload": payload}, f)
+    except OSError:
+        pass

--- a/src/token_tracker/adapters/providers/script.py
+++ b/src/token_tracker/adapters/providers/script.py
@@ -1,0 +1,88 @@
+import json
+import subprocess
+import sys
+from .base import (
+    RateProvider,
+    ProviderRateData,
+    register_provider,
+    get_cached_data,
+    set_cached_data,
+)
+
+
+@register_provider("script")
+class ScriptProvider(RateProvider):
+    """执行外部脚本获取配额数据
+
+    脚本需要输出标准 JSON 格式：
+    {
+        "five_hour": {"used_percentage": 35.2, "resets_at": 1718456789},
+        "seven_day": {"used_percentage": 12.5, "resets_at": 1718976000},
+        "monthly": {"used_percentage": 45.0, "resets_at": 1719784800},
+        "source": "火山方舟"
+    }
+    """
+
+    def __init__(self, command: str, cache_ttl: int = 60, timeout: int = 10):
+        self.command = command
+        self.cache_ttl = cache_ttl
+        self.timeout = timeout
+
+    @classmethod
+    def from_config(cls, config: dict) -> "ScriptProvider":
+        return cls(
+            command=config.get("command", ""),
+            cache_ttl=int(config.get("cache_ttl", 60)),
+            timeout=int(config.get("timeout", 10)),
+        )
+
+    def get_limits(self) -> ProviderRateData | None:
+        if not self.command:
+            return None
+
+        cache_key = self._cache_key()
+        cached = get_cached_data(cache_key, self.cache_ttl)
+        if cached:
+            return self._parse_result(cached)
+
+        try:
+            result = subprocess.run(
+                self.command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout,
+            )
+            if result.returncode != 0:
+                print(f"ScriptProvider: command failed with code {result.returncode}", file=sys.stderr)
+                if result.stderr:
+                    print(f"stderr: {result.stderr[:200]}", file=sys.stderr)
+                return None
+
+            data = json.loads(result.stdout.strip())
+            set_cached_data(cache_key, data)
+            return self._parse_result(data)
+        except subprocess.TimeoutExpired:
+            print(f"ScriptProvider: command timed out after {self.timeout}s", file=sys.stderr)
+            return None
+        except json.JSONDecodeError as e:
+            print(f"ScriptProvider: invalid JSON output: {e}", file=sys.stderr)
+            return None
+        except Exception as e:
+            print(f"ScriptProvider: unexpected error: {e}", file=sys.stderr)
+            return None
+
+    def _parse_result(self, data: dict) -> ProviderRateData:
+        five_hour = data.get("five_hour") or {}
+        seven_day = data.get("seven_day") or {}
+        monthly = data.get("monthly") or {}
+
+        return ProviderRateData(
+            five_hour_pct=five_hour.get("used_percentage"),
+            five_hour_resets_at=five_hour.get("resets_at"),
+            seven_day_pct=seven_day.get("used_percentage"),
+            seven_day_resets_at=seven_day.get("resets_at"),
+            monthly_pct=monthly.get("used_percentage"),
+            monthly_resets_at=monthly.get("resets_at"),
+            source=data.get("source", "script"),
+        )

--- a/src/token_tracker/adapters/rate_limits.py
+++ b/src/token_tracker/adapters/rate_limits.py
@@ -3,11 +3,14 @@ import os
 from datetime import UTC, datetime
 
 from .types import RateLimits, normalize_pct
+from .providers import create_provider
 
 STATUS_FILE = os.path.expanduser("~/.claude/tt-status.json")
+CONFIG_FILE = os.path.expanduser("~/.claude/tt-config.json")
 
 
-def load_rate_limits() -> RateLimits | None:
+def _load_official() -> RateLimits | None:
+    """从 tt-status.json 读取官方注入的配额数据（原有逻辑保留）"""
     if not os.path.exists(STATUS_FILE):
         return None
 
@@ -41,3 +44,52 @@ def load_rate_limits() -> RateLimits | None:
         seven_day_resets_at=seven_reset,
         model=model_name,
     )
+
+
+def _load_config() -> dict | None:
+    """读取用户配置文件"""
+    if not os.path.exists(CONFIG_FILE):
+        return None
+    try:
+        with open(CONFIG_FILE, encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _from_provider_data(data) -> RateLimits:
+    """将 ProviderRateData 转换为 RateLimits"""
+    now_ts = datetime.now(UTC).timestamp()
+    return RateLimits(
+        five_hour_pct=normalize_pct(data.five_hour_pct, data.five_hour_resets_at, now_ts),
+        five_hour_resets_at=data.five_hour_resets_at,
+        seven_day_pct=normalize_pct(data.seven_day_pct, data.seven_day_resets_at, now_ts),
+        seven_day_resets_at=data.seven_day_resets_at,
+        monthly_pct=normalize_pct(data.monthly_pct, data.monthly_resets_at, now_ts),
+        monthly_resets_at=data.monthly_resets_at,
+        model=data.source or "",
+    )
+
+
+def load_rate_limits() -> RateLimits | None:
+    """链式查询配额：官方注入 → 配置的提供者 → None（降级）"""
+    # 1. 优先官方数据（如果有有效配额）
+    official = _load_official()
+    if official and (official.five_hour_pct is not None or official.seven_day_pct is not None):
+        return official
+
+    # 2. 尝试第三方提供者
+    config = _load_config()
+    if config and "rate_provider" in config:
+        provider = create_provider(config["rate_provider"])
+        if provider:
+            data = provider.get_limits()
+            if data and (data.five_hour_pct is not None or data.seven_day_pct is not None or data.monthly_pct is not None):
+                # 保留官方 model 信息，叠加 provider source
+                result = _from_provider_data(data)
+                if official and official.model:
+                    result.model = official.model
+                return result
+
+    # 3. 降级：返回官方数据（即使没有配额，至少有 model 信息）
+    return official

--- a/src/token_tracker/adapters/types.py
+++ b/src/token_tracker/adapters/types.py
@@ -116,6 +116,8 @@ class RateLimits:
     five_hour_resets_at: int | None = None
     seven_day_pct: float | None = None
     seven_day_resets_at: int | None = None
+    monthly_pct: float | None = None
+    monthly_resets_at: int | None = None
     model: str = ""
     plan_type: str = ""
     context_window: int | None = None

--- a/src/token_tracker/cli.py
+++ b/src/token_tracker/cli.py
@@ -345,6 +345,94 @@ def _get_version() -> str:
     return version("token-tracker")
 
 
+def _cmd_quota(args: list[str]) -> None:
+    """诊断配额查询状态"""
+    from .adapters.rate_limits import _load_official, _load_config, load_rate_limits, CONFIG_FILE
+    from .adapters.providers import create_provider
+
+    debug = "--debug" in args or "-d" in args
+
+    console = get_console()
+    console.print("[bold]配额诊断[/bold]")
+    console.print(f"配置文件: {CONFIG_FILE}")
+
+    # 检查配置文件
+    config = _load_config()
+    if config:
+        console.print(f"  [green]✓[/green] 配置文件存在")
+        if debug:
+            import json
+            masked = dict(config)
+            rp = masked.get("rate_provider")
+            if rp:
+                rp = dict(rp)
+                masked["rate_provider"] = rp
+                if rp.get("cookie"):
+                    rp["cookie"] = rp["cookie"][:20] + "..." + rp["cookie"][-10:]
+                if rp.get("command"):
+                    import os as _os
+                    home = _os.path.expanduser("~")
+                    rp["command"] = rp["command"].replace(home, "~")
+            console.print(f"  配置内容: {json.dumps(masked, indent=2, ensure_ascii=False)}")
+    else:
+        console.print(f"  [yellow]○[/yellow] 配置文件不存在")
+
+    # 检查官方数据
+    official = _load_official()
+    if official:
+        has_quota = official.five_hour_pct is not None or official.seven_day_pct is not None
+        status = "✓ 含配额数据" if has_quota else "○ 无配额数据"
+        console.print(f"官方数据: [{ 'green' if has_quota else 'yellow' }]{status}[/{ 'green' if has_quota else 'yellow' }]")
+        if debug:
+            console.print(f"  5h: {official.five_hour_pct}%, 7d: {official.seven_day_pct}%")
+    else:
+        console.print("官方数据: [yellow]○ 无数据[/yellow]")
+
+    # 检查提供者
+    if config and "rate_provider" in config:
+        provider = create_provider(config["rate_provider"])
+        if provider:
+            console.print(f"提供者: [green]✓ {provider.__class__.__name__}[/green]")
+            result = provider.get_limits()
+            if result:
+                console.print(f"  查询成功:")
+                if result.five_hour_pct is not None:
+                    console.print(f"    5h: {result.five_hour_pct}%")
+                if result.seven_day_pct is not None:
+                    console.print(f"    7d: {result.seven_day_pct}%")
+                if result.monthly_pct is not None:
+                    console.print(f"    月: {result.monthly_pct}%")
+                console.print(f"    来源: {result.source}")
+            else:
+                console.print(f"  [red]✗ 查询失败[/red]")
+        else:
+            pt = config["rate_provider"].get("type", "unknown")
+            console.print(f"提供者: [red]✗ 不支持的类型 '{pt}'[/red]")
+    else:
+        console.print("提供者: [yellow]○ 未配置[/yellow]")
+
+    # 最终生效结果
+    final = load_rate_limits()
+    console.print()
+    console.print("[bold]最终生效数据[/bold]")
+    if final:
+        parts = []
+        if final.five_hour_pct is not None:
+            parts.append(f"5h={final.five_hour_pct:.0f}%")
+        if final.seven_day_pct is not None:
+            parts.append(f"7d={final.seven_day_pct:.0f}%")
+        if final.monthly_pct is not None:
+            parts.append(f"月={final.monthly_pct:.0f}%")
+        if parts:
+            console.print(f"  [green]✓[/green] {', '.join(parts)}")
+        else:
+            console.print(f"  [yellow]○[/yellow] 无有效配额数据")
+        if final.model:
+            console.print(f"  模型: {final.model}")
+    else:
+        console.print(f"  [yellow]○[/yellow] 无数据")
+
+
 def main():
     args = sys.argv[1:]
     command = args[0] if args else "dashboard"
@@ -352,6 +440,11 @@ def main():
     # 版本查询不该触发任何文件读写，放在 auto-update 之前短路返回
     if command in ("--version", "-v", "-V"):
         print(f"tt {_get_version()}")
+        return
+
+    # 配额诊断：独立于 setup/auto-update，纯粹查询配置和数据源状态
+    if command == "quota":
+        _cmd_quota(args[1:])
         return
 
     # 已配置过的情况下，任意命令都顺带同步状态栏脚本（setup/unsetup 自行处理）

--- a/src/token_tracker/hooks.py
+++ b/src/token_tracker/hooks.py
@@ -30,7 +30,7 @@ CODEX_STATUS_LINE = [
 HOOK_SCRIPT = r'''#!/usr/bin/env python3
 """Claude Code statusLine — 状态栏显示 + 数据持久化到 tt-status.json"""
 __version__ = "__HOOK_VERSION__"
-import json, os, re, subprocess, sys, tempfile
+import json, os, re, subprocess, sys, tempfile, time
 from datetime import datetime, timezone
 
 STATUS_FILE = os.path.expanduser("~/.claude/tt-status.json")
@@ -64,9 +64,100 @@ def _supports_256color():
     return False
 
 C = THEMES.get(THEME, THEMES["default"]) if _supports_256color() or THEME == "default" else THEMES["default"]
+CONFIG_FILE = os.path.expanduser("~/.claude/tt-config.json")
+CACHE_DIR = os.path.expanduser("~/.cache/token-tracker")
+CACHE_TTL = 60  # 默认值，实际从用户配置读取
 
 if sys.platform == "win32":
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+
+def _load_config():
+    """读取 tt-config.json"""
+    try:
+        with open(CONFIG_FILE, encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def _get_cached_quota(ttl=CACHE_TTL):
+    """读取缓存的配额数据"""
+    cache_file = os.path.join(CACHE_DIR, "tt_statusline_quota.json")
+    try:
+        with open(cache_file, encoding="utf-8") as f:
+            data = json.load(f)
+        if time.time() - data.get("_ts", 0) < ttl:
+            return data.get("payload")
+    except Exception:
+        pass
+    return None
+
+
+def _set_cached_quota(payload):
+    """写入缓存"""
+    try:
+        os.makedirs(CACHE_DIR, exist_ok=True)
+        cache_file = os.path.join(CACHE_DIR, "tt_statusline_quota.json")
+        with open(cache_file, "w", encoding="utf-8") as f:
+            json.dump({"_ts": time.time(), "payload": payload}, f)
+    except Exception:
+        pass
+
+
+def _apply_provider_fallback(data):
+    """官方配额为空时，调用配置的 provider 补充"""
+    # 先检查官方有没有配额
+    rl = data.get("rate_limits") or {}
+    has_official = False
+    for k in ["five_hour", "seven_day", "monthly"]:
+        entry = rl.get(k) or {}
+        if entry.get("used_percentage") is not None:
+            has_official = True
+            break
+    if has_official:
+        return
+
+    # 没有官方配额，尝试走 provider
+    config = _load_config()
+    if not config or "rate_provider" not in config:
+        return
+
+    rp = config["rate_provider"]
+    if rp.get("type") != "script":
+        return  # 状态栏脚本只支持 script provider（不需要额外依赖）
+
+    # 读取用户配置的缓存 TTL，默认 60 秒
+    cache_ttl = int(rp.get("cache_ttl", 60))
+
+    # 先读缓存
+    cached = _get_cached_quota(cache_ttl)
+    if cached:
+        data["rate_limits"] = cached
+        return
+
+    # 执行脚本，默认超时 10 秒
+    try:
+        result = subprocess.run(
+            rp.get("command", ""),
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=int(rp.get("timeout", 10)),
+        )
+        if result.returncode != 0:
+            return
+        provider_data = json.loads(result.stdout.strip())
+        # 把 provider 输出转成 Claude 格式
+        claude_rl = {}
+        for k in ["five_hour", "seven_day", "monthly"]:
+            if k in provider_data:
+                claude_rl[k] = provider_data[k]
+        if claude_rl:
+            data["rate_limits"] = claude_rl
+            _set_cached_quota(claude_rl)
+    except Exception:
+        pass
 
 
 def vlen(s):
@@ -282,6 +373,9 @@ def main():
         data = json.loads(raw)
     except Exception:
         return
+
+    # 第三方配额 fallback：官方没有配额时调用脚本查询
+    _apply_provider_fallback(data)
 
     now = datetime.now(timezone.utc)
     save_data(data, now)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,90 @@
+import json
+import subprocess
+import time
+from pathlib import Path
+from token_tracker.adapters.providers.base import (
+    RateProvider,
+    ProviderRateData,
+    register_provider,
+    create_provider,
+    get_cached_data,
+    set_cached_data,
+    get_cache_dir,
+)
+from token_tracker.adapters.providers.script import ScriptProvider
+
+
+class SampleProvider(RateProvider):
+    def __init__(self, value):
+        self.value = value
+
+    def get_limits(self):
+        return ProviderRateData(five_hour_pct=self.value, source="test")
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(config.get("value", 0))
+
+
+def test_provider_registry():
+    register_provider("test")(SampleProvider)
+    provider = create_provider({"type": "test", "value": 50.0})
+    assert provider is not None
+    result = provider.get_limits()
+    assert result.five_hour_pct == 50.0
+    assert result.source == "test"
+
+
+def test_cache_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr("token_tracker.adapters.providers.base.get_cache_dir", lambda: tmp_path)
+    set_cached_data("test_key", {"five_hour_pct": 75.0})
+    cached = get_cached_data("test_key", 60)
+    assert cached == {"five_hour_pct": 75.0}
+
+
+def test_cache_expired(tmp_path, monkeypatch):
+    monkeypatch.setattr("token_tracker.adapters.providers.base.get_cache_dir", lambda: tmp_path)
+    set_cached_data("expired", {"data": "old"})
+    # 模拟时间流逝
+    import token_tracker.adapters.providers.base as base_mod
+    original_time = time.time
+    monkeypatch.setattr(time, "time", lambda: original_time() + 120)
+    cached = get_cached_data("expired", 60)
+    assert cached is None
+
+
+def test_script_provider_success(tmp_path):
+    script = tmp_path / "test_script.py"
+    script.write_text('''
+import json
+print(json.dumps({
+    "five_hour": {"used_percentage": 35.2, "resets_at": 1718456789},
+    "seven_day": {"used_percentage": 12.5},
+    "source": "test-script"
+}))
+''', encoding="utf-8")
+
+    provider = ScriptProvider(command=f"python {script}", cache_ttl=60)
+    result = provider.get_limits()
+    assert result.five_hour_pct == 35.2
+    assert result.five_hour_resets_at == 1718456789
+    assert result.seven_day_pct == 12.5
+    assert result.seven_day_resets_at is None
+    assert result.source == "test-script"
+
+
+def test_script_provider_timeout(monkeypatch):
+    def mock_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd="test", timeout=1)
+    monkeypatch.setattr(subprocess, "run", mock_run)
+    provider = ScriptProvider(command="sleep 5", cache_ttl=60)
+    result = provider.get_limits()
+    assert result is None
+
+
+def test_script_provider_invalid_json(tmp_path):
+    script = tmp_path / "bad_script.py"
+    script.write_text('print("not json")', encoding="utf-8")
+    provider = ScriptProvider(command=f"python {script}", cache_ttl=60)
+    result = provider.get_limits()
+    assert result is None


### PR DESCRIPTION
## Summary

- 新增 Provider 插件架构，通过 ScriptProvider 执行外部脚本获取第三方平台（如火山方舟、OpenCode GO）的 Coding Plan 配额数据
- 状态栏自动 fallback：官方 API 有配额时用官方数据，无配额时调用配置的脚本补充
- 新增 `tt quota` 诊断命令，支持 `--debug` 模式查看配置和脱敏信息
- 中英文 README 新增完整的配置说明、脚本输出格式、火山方舟+OpenCode GO样例

## 改动文件

| 文件 | 说明 |
|------|------|
| `adapters/providers/base.py` | Provider 基类、注册机制、文件缓存 |
| `adapters/providers/script.py` | ScriptProvider 实现 |
| `adapters/providers/__init__.py` | 模块导出 + 预导入触发注册 |
| `adapters/rate_limits.py` | 链式查询：官方 → 第三方 → 降级 |
| `adapters/types.py` | RateLimits 新增 monthly 字段 |
| `hooks.py` | 状态栏内嵌 Provider Fallback |
| `cli.py` | 新增 `tt quota` 诊断命令 |
| `tests/test_providers.py` | 6 个测试覆盖注册、缓存、成功/超时/无效 JSON |
| `README.md` / `README_EN.md` | 第三方配额对接使用说明 |

## 使用方式

1. 创建查询脚本（如 `~/.claude/tt-ark-quota.py`），输出标准 JSON
2. 在 `~/.claude/tt-config.json` 中配置 provider
3. 运行 `tt quota` 验证，状态栏自动显示

## 对接结果样例
<img width="1158" height="195" alt="image" src="https://github.com/user-attachments/assets/e12a644f-9fb5-4188-b6e0-11e6083dcecd" />

## Test plan

- [x] 51 个测试全部通过
- [x] `tt quota` 命令正常输出诊断信息
- [x] `tt quota --debug` 脱敏 cookie 和用户路径
- [x] 状态栏无官方配额时自动调用脚本并缓存
- [x] 缓存 TTL 和超时从用户配置读取