### PR TITLE
feat(statusline): get_width 读 COLUMNS + vlen 按 CJK 显示宽度（管道 stdin 下不折行）

### DIFF
--- a/src/token_tracker/templates/claude_statusline.py
+++ b/src/token_tracker/templates/claude_statusline.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Claude Code statusLine — 状态栏显示 + 数据持久化到 tt-status.json"""
 __version__ = "__HOOK_VERSION__"
-import json, os, re, subprocess, sys, tempfile
+import json, os, re, subprocess, sys, tempfile, unicodedata
 from datetime import datetime, timezone
 
 STATUS_FILE = os.path.join(os.path.expanduser("~/.config/token-tracker"), "tt-status.json")
@@ -21,10 +21,24 @@ if sys.platform == "win32":
 
 
 def vlen(s):
-    return len(ANSI_RE.sub("", s))
+    # 显示宽度：东亚全角/宽字符占 2 列（wizard.py 已用同一规则）。项目名/分支/模型名含
+    # CJK 时，按字符数少算会让窄终端的收窄判断失准、行溢出折行——按列宽计才准。
+    return sum(2 if unicodedata.east_asian_width(ch) in ('W', 'F') else 1
+               for ch in ANSI_RE.sub("", s))
 
 
 def get_width():
+    # COLUMNS：Claude Code 会为 statusLine 子进程设置真实列宽（CC v2.1.153+）。该子进程的
+    # stdin/stderr 是管道，get_terminal_size/dev-tty 都探测不到，故优先用它。与 ui/console.py
+    # 同规矩：只认有效正整数（`!` 子进程占位的 "0"、非数字都忽略，回落原有探测链，无回归）。
+    try:
+        c = os.environ.get("COLUMNS")
+        if c and c.isdigit():
+            w = int(c)
+            if w > 0:
+                return max(1, w - 4)
+    except Exception:
+        pass
     try:
         return max(1, os.get_terminal_size(2).columns - 4)
     except Exception:


### PR DESCRIPTION
## 背景 / Why

Claude Code 会为 statusLine 子进程设置真实列宽到 `COLUMNS`（CC v2.1.153+），但该子进程的 **stdin/stderr 是管道**，所以 `claude_statusline.py` 里的 `get_width()` 走 `os.get_terminal_size(2)` / `/dev/tty` **都探测不到**，只能回落到硬编码的 `116`。结果：**窄面板（分屏 / 竖排布局）整行超宽折行**，收窄逻辑形同虚设。

另外 `vlen()` 用 `len()` 计长度，**CJK 项目名/分支/模型名按字符数少算**（全角字符实际占 2 列），进一步让收窄判断失准。

这两点都是**纯宽度测量**问题，本 PR 只补这两处原语，**不动主题、降级顺序、布局**。

## 改动 / What

`src/token_tracker/templates/claude_statusline.py`：

1. **`get_width()` 优先读 `COLUMNS`**，再回落原有 `get_terminal_size` / `/dev/tty` / `116` 链。判定规矩与仓库现有 `ui/console.py::_forced_width()` **完全一致**：只认有效正整数，`!` 子进程占位的 `"0"`、非数字都忽略 → 回落原链，**无回归**。
2. **`vlen()` 按东亚全角/宽字符计 2 列** —— 用的正是仓库 `wizard.py:141` 已有的同一条 `unicodedata.east_asian_width(...) in ('W','F')` 规则。

## 验证 / Verified

用管道喂 payload（含 CJK 项目名 `测试项目-令牌追踪`）本地渲染，`COLUMNS=60`（面板宽度预算 56 列）：

**改前（现状）** —— `get_terminal_size` 在管道上失败 → 回落 116 → 忽略 60 列面板：
```
L2 w= 80 (<= 56)  <-- OVER: Limit: 5h:███░░░░░ 42% (1h21m) | 7d:██████░░ 73% (6d10h) | 200k Ctx:████░░░░ 55%
```

**改后** —— `get_width()` 读到 `COLUMNS=60` → 用仓库原有的降级逻辑收窄到贴合：
```
L2 w= 52 (<= 56): Limit: 5h:██░░ 42% | 7d:███░ 73% | 200k Ctx:██░░ 55%
```

`COLUMNS=200/120/80/60` 各档渲染均落在各自宽度预算内；CJK 字符全程按 2 列计。

## 说明 / Notes

- 这个宽度修复来自我们本地一份 v0.3.5 派生分叉里长期在用的独立 statusline，回移到当前 0.4.x 模板上游。
- **仅** `claude_statusline.py` 需要改：`codex_statusline.py` 没有 `get_width`/`vlen`。
- 不涉及 `__HOOK_VERSION__` / 主题占位符的注入机制。

---

**English summary:** Claude Code pipes stdin/stderr to the statusLine subprocess, so the template's `get_width()` (`os.get_terminal_size`/`/dev/tty`) can't detect width and falls back to `116`, overflowing narrow panes. This PR makes `get_width()` read `COLUMNS` first (same valid-positive-integer rule as the repo's own `ui/console.py`), and makes `vlen()` count East-Asian wide/fullwidth glyphs as 2 columns (same `east_asian_width` rule already used in `wizard.py`). Width-measurement only — theme, degrade order, and layout are untouched. Before/after at `COLUMNS=60` shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
