### PR TITLE
fix: install.sh 兼容 Windows venv 布局与 GBK 控制台

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,9 +30,15 @@ elif command -v python3 >/dev/null 2>&1 && python3 -m venv -h >/dev/null 2>&1; t
     VENV_DIR="$HOME/.local/share/token-tracker/venv"
     BIN_DIR="$HOME/.local/bin"
     python3 -m venv "$VENV_DIR"
-    "$VENV_DIR/bin/pip" install --upgrade "$PKG"
+    # Windows（Git Bash / MSYS2）下 venv 可执行目录是 Scripts/ 而非 bin/，
+    # 可执行文件带 .exe 后缀；按实际布局探测，Unix 行为不变。
+    VENV_BIN="$VENV_DIR/bin"
+    [ -d "$VENV_BIN" ] || VENV_BIN="$VENV_DIR/Scripts"
+    "$VENV_BIN/pip" install --upgrade "$PKG"
     mkdir -p "$BIN_DIR"
-    ln -sf "$VENV_DIR/bin/tt" "$BIN_DIR/tt"
+    TT_NAME="tt"
+    [ -f "$VENV_BIN/tt.exe" ] && TT_NAME="tt.exe"
+    ln -sf "$VENV_BIN/$TT_NAME" "$BIN_DIR/tt"
     TT_BIN="$BIN_DIR/tt"
 
 else
@@ -161,9 +167,11 @@ fi
 # 注册 fd 失败 OSError [Errno 22]）。改用：让 tt setup 看到 non-tty stdin →
 # 自动走 _auto_setup 默认全装（语言跟随系统 / mocha / 组件全开），不崩。
 # 想自定义的用户末尾会看到明确提示，去独立终端跑 `tt setup` 即可。
+# PYTHONUTF8=1：Windows GBK 控制台下 rich 输出 ✓ 等字符会
+# UnicodeEncodeError 导致 setup 崩溃，强制 UTF-8 模式规避（其他平台无影响）。
 say ""
 say "Configuring status bar..."
-"$TT_BIN" setup
+PYTHONUTF8=1 "$TT_BIN" setup
 
 say ""
 say "Done! Run 'tt' to start."


### PR DESCRIPTION
## 问题

Windows（Git Bash / MSYS2）下运行官方安装命令失败：

```
Installing token-tracker into a private venv (~/.local/share/token-tracker)...
bash: line 33: /c/Users/null/.local/share/token-tracker/venv/bin/pip: No such file or directory
```

两个原因：

1. **venv 布局差异**：Windows 下 `python -m venv` 生成的可执行目录是 `Scripts/` 而非 `bin/`，且可执行文件带 `.exe` 后缀（`Scripts/pip.exe`、`Scripts/tt.exe`）。脚本写死了 `$VENV_DIR/bin/pip`，uv / pipx 都不可用时会走到私有 venv 分支，直接失败。
2. **GBK 控制台崩溃**：修好上面后，安装末尾的 `tt setup` 在 Windows GBK（cp936）控制台下输出 `✓` 等字符时 rich 抛 `UnicodeEncodeError: 'gbk' codec can't encode character '\u2713'`，配置向导中途崩溃。

## 改动（仅 install.sh，+11/-3）

- venv 分支按实际布局探测：`bin/` 不存在则退回 `Scripts/`；链接启动器时优先 `tt.exe`。Unix 行为完全不变。
- 安装末尾的 `tt setup` 调用加 `PYTHONUTF8=1`，规避 GBK 编码崩溃（其他平台无影响）。

## 测试

Windows 11 + Git Bash + Python 3.13.14 实测：

- 修复前：`curl ... | bash` 在 venv 分支报 `bin/pip: No such file or directory` 退出
- 修复后：完整跑通 → venv 安装成功 → `~/.local/bin/tt` 可执行 → 配置向导自动完成 → `tt status` 正常出报表

`bash -n` 语法检查通过；改动不涉及 Python 代码，CI 无影响。
