### PR TITLE
fix: Codex hooks 使用 HOME 便携路径并保持幂等

### DIFF
--- a/src/token_tracker/hooks.py
+++ b/src/token_tracker/hooks.py
@@ -211,7 +211,13 @@ def _read_codex_config() -> tuple[str, dict] | None:
 
 
 def _codex_statusline_command(python: str | None = None) -> str:
-    return _build_cc_command(python or sys.executable or "python3", CODEX_STATUSLINE_HOOK_PATH)
+    executable = python or sys.executable or "python3"
+    if os.name != "nt":
+        home = os.path.realpath(os.path.expanduser("~"))
+        paths = (os.path.abspath(executable), os.path.abspath(CODEX_STATUSLINE_HOOK_PATH))
+        if all(os.path.commonpath((home, path)) == home for path in paths):
+            return " ".join(sidebar_install._portable_shell_path(path) for path in paths)
+    return _build_cc_command(executable, CODEX_STATUSLINE_HOOK_PATH)
 
 
 def _inline_codex_statusline_present() -> bool:

--- a/src/token_tracker/sidebar_install.py
+++ b/src/token_tracker/sidebar_install.py
@@ -38,19 +38,24 @@ def _load_skill_resource(relative_path: str, package: str = _SKILL_PACKAGE) -> s
     return node.read_text(encoding="utf-8")
 
 
-def build_module_command(python: str, action: str) -> str:
-    """生成 Skill / Hook 共用的绝对解释器命令；不依赖 GUI Codex 的 PATH。"""
+def _portable_shell_path(path: str) -> str:
+    """将 HOME 内路径缩写为可安全展开的 shell 参数，其它路径保持绝对形式。"""
     if os.name == "nt":
-        python = python.replace("\\", "/")
-    else:
-        home = os.path.realpath(os.path.expanduser("~"))
-        executable = os.path.abspath(python)
-        if os.path.commonpath((home, executable)) == home:
-            relative = os.path.relpath(executable, home)
-            if all(char.isalnum() or char in "._-/" for char in relative):
-                return f'"$HOME/{relative}" -B -m token_tracker.sidebar_command {action}'
-            return f'"$HOME"/{shlex.quote(relative)} -B -m token_tracker.sidebar_command {action}'
-    return f'"{python}" -B -m token_tracker.sidebar_command {action}'
+        path = path.replace("\\", "/")
+        return f'"{path}"'
+    home = os.path.realpath(os.path.expanduser("~"))
+    absolute = os.path.abspath(path)
+    if os.path.commonpath((home, absolute)) != home:
+        return f'"{path}"'
+    relative = os.path.relpath(absolute, home)
+    if all(char.isalnum() or char in "._-/" for char in relative):
+        return f'"$HOME/{relative}"'
+    return f'"$HOME"/{shlex.quote(relative)}'
+
+
+def build_module_command(python: str, action: str) -> str:
+    """生成 Skill / Hook 共用的解释器命令；不依赖 GUI Codex 的 PATH。"""
+    return f'{_portable_shell_path(python)} -B -m token_tracker.sidebar_command {action}'
 
 
 def render_skill(relative_path: str, package: str = _SKILL_PACKAGE) -> str:

--- a/src/token_tracker/sidebar_install.py
+++ b/src/token_tracker/sidebar_install.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import stat
 import sys
 import tomllib
@@ -41,6 +42,14 @@ def build_module_command(python: str, action: str) -> str:
     """生成 Skill / Hook 共用的绝对解释器命令；不依赖 GUI Codex 的 PATH。"""
     if os.name == "nt":
         python = python.replace("\\", "/")
+    else:
+        home = os.path.realpath(os.path.expanduser("~"))
+        executable = os.path.abspath(python)
+        if os.path.commonpath((home, executable)) == home:
+            relative = os.path.relpath(executable, home)
+            if all(char.isalnum() or char in "._-/" for char in relative):
+                return f'"$HOME/{relative}" -B -m token_tracker.sidebar_command {action}'
+            return f'"$HOME"/{shlex.quote(relative)} -B -m token_tracker.sidebar_command {action}'
     return f'"{python}" -B -m token_tracker.sidebar_command {action}'
 
 
@@ -171,6 +180,58 @@ def _prompt_hook_handler() -> dict:
         ),
         "timeout": 2,
     }
+
+
+def _resolve_prompt_hook_executable(value: str) -> str | None:
+    """仅解析 Hook 支持的解释器路径写法，拒绝其它 shell 语义。"""
+    if os.name == "nt":
+        return os.path.realpath(value) if os.path.isabs(value) else None
+    home = os.path.realpath(os.path.expanduser("~"))
+    if value.startswith("$HOME/"):
+        value = os.path.join(home, value.removeprefix("$HOME/"))
+    elif value.startswith("${HOME}/"):
+        value = os.path.join(home, value.removeprefix("${HOME}/"))
+    elif value.startswith("~/"):
+        value = os.path.join(home, value.removeprefix("~/"))
+    elif not os.path.isabs(value):
+        return None
+    return os.path.realpath(value)
+
+
+def _prompt_hook_command_matches(command: str) -> bool:
+    """只把同一解释器的纯 prompt-hook 命令视为等价。"""
+    try:
+        argv = shlex.split(command, posix=True)
+    except ValueError:
+        return False
+    expected = [
+        sys.executable or "python3",
+        "-B",
+        "-m",
+        "token_tracker.sidebar_command",
+        "prompt-hook",
+        "--agent",
+        "codex",
+    ]
+    actual_executable = _resolve_prompt_hook_executable(argv[0]) if argv else None
+    expected_executable = _resolve_prompt_hook_executable(expected[0])
+    return (
+        argv[1:] == expected[1:]
+        and actual_executable is not None
+        and actual_executable == expected_executable
+    )
+
+
+def _prompt_hook_handler_matches(handler: object) -> bool:
+    expected = _prompt_hook_handler()
+    return (
+        isinstance(handler, dict)
+        and set(handler) == set(expected)
+        and handler.get("type") == expected["type"]
+        and handler.get("timeout") == expected["timeout"]
+        and isinstance(handler.get("command"), str)
+        and _prompt_hook_command_matches(handler["command"])
+    )
 
 
 def _statusline_hook_handler(command: str) -> dict:
@@ -316,11 +377,28 @@ def _with_managed_hooks(data: dict, statusline_command: str | None) -> dict:
     return result
 
 
+def _managed_hooks_equivalent(current: object, expected: object) -> bool:
+    """仅放宽 Token Tracker 自己的 Codex prompt-hook 解释器路径表示。"""
+    if expected == _prompt_hook_handler():
+        return _prompt_hook_handler_matches(current)
+    if type(current) is not type(expected):
+        return False
+    if isinstance(expected, dict):
+        return set(current) == set(expected) and all(
+            _managed_hooks_equivalent(current[key], value) for key, value in expected.items()
+        )
+    if isinstance(expected, list):
+        return len(current) == len(expected) and all(
+            _managed_hooks_equivalent(left, right) for left, right in zip(current, expected, strict=True)
+        )
+    return current == expected
+
+
 def managed_hooks_need_sync(statusline_command: str | None) -> bool:
     """两个 Token Tracker Hook 是否需要统一同步到用户级 hooks.json。"""
     try:
         data = _read_hooks()
-        return data != _with_managed_hooks(data, statusline_command)
+        return not _managed_hooks_equivalent(data, _with_managed_hooks(data, statusline_command))
     except ValueError:
         return False  # 损坏配置只在显式 setup 时提示，自动更新绝不覆盖
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -395,6 +395,34 @@ def test_codex_statusline_windows_path_is_json_safe(tmp_path, monkeypatch):
     assert parsed["hooks"]["Stop"][0]["hooks"][0]["command"] == command
 
 
+def test_codex_statusline_home_command_is_portable_and_idempotent(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    executable = home / ".local" / "bin" / "python"
+    script = home / ".config" / "token-tracker" / "codex-statusline.py"
+    codex_hooks = tmp_path / "hooks.json"
+    monkeypatch.setattr(hooks, "CODEX_STATUSLINE_HOOK_PATH", str(script))
+    monkeypatch.setattr(hooks.sys, "executable", str(executable))
+    monkeypatch.setattr(sidebar_install, "CODEX_HOOKS", str(codex_hooks))
+    monkeypatch.setattr(sidebar_install.os.path, "expanduser", lambda value: str(home) if value == "~" else value)
+
+    command = hooks._codex_statusline_command()
+    assert command == '"$HOME/.local/bin/python" "$HOME/.config/token-tracker/codex-statusline.py"'
+    assert sidebar_install.install_managed_hooks(command)
+    assert not sidebar_install.managed_hooks_need_sync(command)
+    assert not sidebar_install.install_managed_hooks(command)
+
+
+def test_codex_statusline_external_path_stays_absolute(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    executable = home / ".local" / "bin" / "python"
+    script = tmp_path / "external" / "codex-statusline.py"
+    monkeypatch.setattr(hooks, "CODEX_STATUSLINE_HOOK_PATH", str(script))
+    monkeypatch.setattr(hooks.sys, "executable", str(executable))
+    monkeypatch.setattr(sidebar_install.os.path, "expanduser", lambda value: str(home) if value == "~" else value)
+
+    assert hooks._codex_statusline_command() == f'"{executable}" "{script}"'
+
+
 def test_codex_statusline_version_roundtrip(tmp_path, monkeypatch):
     # _installed_codex_statusline_version 读回的版本应与写入的 STATUSLINE_HOOK_VERSION 一致，
     # 保证 needs_update 不会因解析偏差而误判。

--- a/tests/test_sidebar_install.py
+++ b/tests/test_sidebar_install.py
@@ -84,6 +84,69 @@ def test_hook_merge_idempotent_and_uninstall_preserves_user(tmp_path, monkeypatc
     }
 
 
+@pytest.mark.parametrize(
+    "command_template",
+    [
+        '"{executable}" -B -m token_tracker.sidebar_command prompt-hook --agent codex',
+        '"$HOME/.local/bin/python" -B -m token_tracker.sidebar_command prompt-hook --agent codex',
+        '"${{HOME}}/.local/bin/python" -B -m token_tracker.sidebar_command prompt-hook --agent codex',
+        '"~/.local/bin/python" -B -m token_tracker.sidebar_command prompt-hook --agent codex',
+    ],
+)
+def test_managed_hooks_treats_home_and_absolute_python_as_equivalent(tmp_path, monkeypatch, command_template):
+    home = tmp_path / "home"
+    executable = home / ".local" / "bin" / "python"
+    path = tmp_path / "hooks.json"
+    path.write_text(json.dumps({"hooks": {"UserPromptSubmit": [{"hooks": [{
+        "type": "command",
+        "command": command_template.format(executable=executable),
+        "timeout": 2,
+    }]}]}}), encoding="utf-8")
+    monkeypatch.setattr(sidebar_install, "CODEX_HOOKS", str(path))
+    monkeypatch.setattr(sidebar_install.sys, "executable", str(executable))
+    monkeypatch.setattr(sidebar_install.os.path, "expanduser", lambda value: str(home) if value == "~" else value)
+
+    assert sidebar_install._prompt_hook_handler()["command"].startswith('"$HOME/.local/bin/python"')
+    assert not sidebar_install.managed_hooks_need_sync(None)
+
+
+def test_portable_prompt_hook_install_is_idempotent(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    executable = home / ".venv" / "bin" / "python"
+    path = tmp_path / "hooks.json"
+    monkeypatch.setattr(sidebar_install, "CODEX_HOOKS", str(path))
+    monkeypatch.setattr(sidebar_install.sys, "executable", str(executable))
+    monkeypatch.setattr(sidebar_install.os.path, "expanduser", lambda value: str(home) if value == "~" else value)
+
+    assert sidebar_install.install_managed_hooks(None)
+    command = json.loads(path.read_text(encoding="utf-8"))["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"]
+    assert command.startswith('"$HOME/.venv/bin/python"')
+    assert not sidebar_install.install_managed_hooks(None)
+    assert not sidebar_install.managed_hooks_need_sync(None)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        '"/other/python" -B -m token_tracker.sidebar_command prompt-hook --agent codex',
+        '"$HOME/.venv/bin/python" -B -m token_tracker.sidebar_command prompt-hook --agent other',
+        '"$HOME/.venv/bin/python" -B -m token_tracker.sidebar_command prompt-hook --agent codex; echo stale',
+    ],
+)
+def test_managed_hooks_rejects_different_python_or_prompt_hook_semantics(tmp_path, monkeypatch, command):
+    home = tmp_path / "home"
+    executable = home / ".venv" / "bin" / "python"
+    path = tmp_path / "hooks.json"
+    path.write_text(json.dumps({"hooks": {"UserPromptSubmit": [{"hooks": [{
+        "type": "command", "command": command, "timeout": 2,
+    }]}]}}), encoding="utf-8")
+    monkeypatch.setattr(sidebar_install, "CODEX_HOOKS", str(path))
+    monkeypatch.setattr(sidebar_install.sys, "executable", str(executable))
+    monkeypatch.setattr(sidebar_install.os.path, "expanduser", lambda value: str(home) if value == "~" else value)
+
+    assert sidebar_install.managed_hooks_need_sync(None)
+
+
 def test_managed_hooks_merge_both_events_and_uninstall_preserves_user(tmp_path, monkeypatch):
     path = tmp_path / ".codex" / "hooks.json"
     path.parent.mkdir()


### PR DESCRIPTION
## 问题

Codex sidebar 与 Stop hook 将当前 Python 解释器写成用户家目录的绝对路径。配置纳入版本控制或跨机器恢复后，会产生本机路径泄露和无效漂移。

## 修改

- HOME 内解释器路径生成 `$HOME/...` 形式；HOME 外与 Windows 保持绝对路径。
- `managed_hooks_need_sync` 将 `$HOME`、`${HOME}`、`~` 与同一解释器绝对路径视为等价。
- Codex Stop statusline 的 Python 与脚本路径复用同一便携路径规则。
- 不同解释器、错误参数和额外 Shell 语义仍判定需要同步。

## 验证

- `tests/test_sidebar_install.py tests/test_hooks.py`：101 passed
- Ruff：通过
- `git diff --check`：通过
