### PR TITLE
fix: make Kimi statusline work on Windows

### DIFF
--- a/src/token_tracker/hooks.py
+++ b/src/token_tracker/hooks.py
@@ -157,7 +157,7 @@ def _installed_kimi_statusline_version() -> str | None:
 
 
 def _kimi_statusline_command(python: str | None = None) -> str:
-    return _build_cc_command(python or sys.executable or "python3", KIMI_STATUSLINE_HOOK_PATH)
+    return _build_kimi_command(python or sys.executable or "python3", KIMI_STATUSLINE_HOOK_PATH)
 
 
 def kimi_statusline_active() -> bool:
@@ -344,6 +344,16 @@ def _build_cc_command(python: str, script: str) -> str:
     if os.name == "nt":
         python = python.replace("\\", "/")
         script = script.replace("\\", "/")
+    return f'"{python}" "{script}"'
+
+
+def _build_kimi_command(python: str, script: str) -> str:
+    """Avoid quotes that Kimi's Windows cmd.exe spawn escapes literally."""
+    if os.name == "nt":
+        python = python.replace("\\", "/")
+        script = script.replace("\\", "/")
+        if " " not in python and " " not in script:
+            return f"{python} {script}"
     return f'"{python}" "{script}"'
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -866,6 +866,16 @@ def test_build_cc_command_unix_always_quoted(monkeypatch):
     assert "John Doe" in cmd  # 含空格路径被引号包住、能正确执行
 
 
+def test_build_kimi_command_windows_avoids_escaped_quotes(monkeypatch):
+    # issue #29：Kimi 用 cmd.exe spawn，内层双引号会被转义成字面量，默认无空格路径应裸传。
+    monkeypatch.setattr(hooks.os, "name", "nt")
+    cmd = hooks._build_kimi_command(
+        r"C:\Python311\python.exe",
+        r"C:\Users\X\.config\token-tracker\kimi-statusline.py",
+    )
+    assert cmd == "C:/Python311/python.exe C:/Users/X/.config/token-tracker/kimi-statusline.py"
+
+
 def test_cc_command_outdated_detects_legacy_format(monkeypatch):
     # 旧格式（裸拼接、无引号）应被检测为过时；新格式不动。
     monkeypatch.setattr(hooks.os, "name", "posix")


### PR DESCRIPTION
## 问题

Kimi Code 在 Windows 上通过 `cmd.exe /d /s /c` 启动 statusline 命令。复用 Claude Code 的命令构造器会给 Python 和脚本路径加内层双引号，Kimi 的 Node spawn 会将这些引号转义成字面量，导致默认安装路径下命令无法执行。

## 修复

- 为 Kimi 单独构造 Windows 命令：转换为正斜杠，并在默认无空格路径下不添加双引号
- 保持 Claude Code / Codex 的现有引号行为不变
- 增加 Windows 命令回归测试

Closes #29

## 验证

- `pytest tests/test_hooks.py -q`：71 passed
- `pytest -q -k 'not test_alive_pids_own_process_and_start_time_guard'`：其余 344 passed
- `ruff check .`：passed
- `mypy src/token_tracker`：passed

完整测试在当前 macOS 环境有 1 个与本次改动无关的既有失败：`tests/test_sidebar.py::test_alive_pids_own_process_and_start_time_guard`，该测试依赖本机进程启动时间探测；本次仅改动 `hooks.py` 及其测试。
