### PR TITLE
feat(statusline): Limit 行显示按模型的周额度（Fable）

### DIFF
--- a/src/token_tracker/templates/claude_statusline.py
+++ b/src/token_tracker/templates/claude_statusline.py
@@ -6,6 +6,13 @@ from datetime import datetime, timezone
 
 STATUS_FILE = os.path.join(os.path.expanduser("~/.config/token-tracker"), "tt-status.json")
 ANSI_RE = re.compile(r'\033\[[0-9;]*m')
+# Limit 行的分隔线分粗细：共用同一个重置窗口的相邻段之间用细线，其余用粗线。加入按模型的
+# 周额度后 Limit 行有了「7d 与该额度同属一个周窗口」这层结构，靠粗细区分才不会读成并列。
+# 两者可见宽度都与旧的 " | " 相同（3 列），窄终端的收窄判断无回归。
+SEP_LIMIT = " \033[2m\u2503\033[0m "
+SEP_LIMIT_GROUPED = " \033[2m\u2502\033[0m "
+# 缓存超过这个秒数就认为过期（与 Claude Code 自己判定 cachedUsageUtilization 的阈值一致）
+SCOPED_QUOTA_STALE_S = 3600
 # 配色在 tt setup / update_hook 烘焙时由 themes.theme_to_statusline_ansi(当前主题) 注入：
 # THEME_COLORS 为当前主题 truecolor，THEME_COLORS_256 为同主题的 256 色近似（兜底不支持
 # truecolor 的终端，如 macOS Terminal.app）。只认 COLORTERM=truecolor/24bit 走真彩，否则降 256。
@@ -227,6 +234,75 @@ def _read_transcript_totals(path):
     return inp, out, cache
 
 
+def _join_limit_segs(segs):
+    """segs: [(text, grouped_with_previous)]，grouped 的用细线接到前一段。
+    只有真的出现成组的相邻段时，其余分隔才升级为粗线——没有按模型额度可显示的用户
+    （拿不到 weekly_scoped 桶的账号）看到的仍是原来的 " | "，零视觉变化。"""
+    if not segs:
+        return ""
+    normal = SEP_LIMIT if any(grouped for _, grouped in segs[1:]) else " | "
+    out = segs[0][0]
+    for text, grouped in segs[1:]:
+        out += (SEP_LIMIT_GROUPED if grouped else normal) + text
+    return out
+
+
+def _claude_config_dir(data):
+    """定位当前账号的 Claude Code config dir。transcript_path 最可靠（它就在 config dir 下），
+    CLAUDE_CONFIG_DIR 与 ~/.claude 兜底。注意**不要**解析 symlink：projects/ 可能被指到共享
+    目录，解析后会走出 config dir 一路上溯到 $HOME，命中旧版本遗留的 ~/.claude.json。"""
+    home = os.path.expanduser("~")
+    transcript = data.get("transcript_path") or ""
+    if transcript:
+        d = os.path.dirname(os.path.abspath(transcript))
+        while d and d not in (home, os.path.dirname(home)):
+            if os.path.exists(os.path.join(d, ".claude.json")):
+                return d
+            parent = os.path.dirname(d)
+            if parent == d:
+                break
+            d = parent
+    return os.environ.get("CLAUDE_CONFIG_DIR") or os.path.join(home, ".claude")
+
+
+def _scoped_quota(data, now_ts):
+    """按模型计的周额度（当前是 Fable）。statusLine 的 payload 里没有这个桶——构造 payload 的
+    那段只 spread five_hour / seven_day / spend_limit。但 Claude Code 会把 /api/oauth/usage 的
+    响应缓存到 <config dir>/.claude.json，读缓存即可，不联网、不接触 OAuth token。
+    返回 (label, pct, resets_at, stale)，取不到则 None。"""
+    try:
+        with open(os.path.join(_claude_config_dir(data), ".claude.json"), encoding="utf-8") as f:
+            cached = json.load(f).get("cachedUsageUtilization") or {}
+    except (OSError, json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        return None  # 文件不存在，或读到 CC 写了一半的内容——静默略过，不影响其余段
+    hit = None
+    for entry in ((cached.get("utilization") or {}).get("limits") or []):
+        if not isinstance(entry, dict) or entry.get("kind") != "weekly_scoped":
+            continue
+        if entry.get("percent") is None:
+            continue
+        name = ((entry.get("scope") or {}).get("model") or {}).get("display_name")
+        if name:
+            hit = (name, entry)
+            break
+    if hit is None:
+        return None
+    label, entry = hit
+
+    resets_at = None
+    raw = entry.get("resets_at")
+    if isinstance(raw, str) and raw:
+        try:
+            resets_at = int(datetime.fromisoformat(raw).timestamp())
+        except ValueError:
+            resets_at = None
+
+    fetched = cached.get("fetchedAtMs")
+    stale = (not isinstance(fetched, (int, float))
+             or (now_ts * 1000 - fetched) > SCOPED_QUOTA_STALE_S * 1000)
+    return label, float(entry["percent"]), resets_at, stale
+
+
 def render(data, now, tps=None):
     W = get_width()
     ctx = data.get("context_window") or {}
@@ -278,24 +354,48 @@ def render(data, now, tps=None):
     while len(line1) > 1 and vlen(" | ".join(line1)) > W:
         line1.pop()
 
-    # --- Line 2: Limit: 5h | 7d | Ctx ---
+    # --- Line 2: Limit: 5h ┃ 7d │ <model> ┃ Ctx（无按模型额度时退回 5h | 7d | Ctx）---
     rl = data.get("rate_limits") or {}
+    quota = _scoped_quota(data, now.timestamp())
+    seven = rl.get("seven_day") or {}
+
+    # 7d 与按模型的周额度是同一个周窗口，重置倒计时相同；重复打两遍纯属噪音，
+    # 只在这一对的后者上打一次。窗口真的不同（或缓存里没有 resets_at）时各打各的。
+    share_reset = False
+    if quota is not None and quota[2] is not None and seven.get("resets_at"):
+        share_reset = abs(int(seven["resets_at"]) - int(quota[2])) <= 120
+
+    def _limit_tiers(label, pct, resets_at, with_reset, suffix=""):
+        """一段的三档渲染：带倒计时 / 不带 / 只留百分数。"""
+        reset_str = ""
+        if with_reset and resets_at:
+            remain = int(resets_at) - int(now.timestamp())
+            if remain > 0:
+                reset_str = f" \033[2m{C['label']}({fmt_duration(remain)}){C['reset']}"
+        return (
+            f"{C['label']}{label}:{C['reset']}{progress_bar(pct, bar_w)}{suffix}{reset_str}",
+            f"{C['label']}{label}:{C['reset']}{progress_bar(pct, bar_w)}{suffix}",
+            f"{C['label']}{label}:{pct:.0f}%{suffix}{C['reset']}",
+        )
+
+    # (三档渲染, 是否与前一段共用重置窗口, 是否是按模型的额度段)
     rl_parts = []
     for key, label in [("five_hour", "5h"), ("seven_day", "7d")]:
         entry = rl.get(key) or {}
         pct = entry.get("used_percentage")
         if pct is not None:
-            reset_str = ""
-            resets_at = entry.get("resets_at")
-            if resets_at:
-                remain = int(resets_at) - int(now.timestamp())
-                if remain > 0:
-                    reset_str = f" \033[2m{C['label']}({fmt_duration(remain)}){C['reset']}"
             rl_parts.append((
-                f"{C['label']}{label}:{C['reset']}{progress_bar(pct, bar_w)}{reset_str}",
-                f"{C['label']}{label}:{C['reset']}{progress_bar(pct, bar_w)}",
-                f"{C['label']}{label}:{pct:.0f}%{C['reset']}",
+                _limit_tiers(label, pct, entry.get("resets_at"),
+                             not (key == "seven_day" and share_reset)),
+                False, False,
             ))
+    if quota is not None:
+        q_label, q_pct, q_reset, q_stale = quota
+        rl_parts.append((
+            _limit_tiers(q_label, q_pct, q_reset, True,
+                         f"\033[2m~{C['reset']}" if q_stale else ""),
+            share_reset, True,
+        ))
     ctx_parts = []
     if ctx.get("used_percentage") is not None:
         size = ctx.get("context_window_size", 0)
@@ -305,14 +405,17 @@ def render(data, now, tps=None):
         ]
     line2 = []
     if rl_parts or ctx_parts:
-        for idx in (0, 1, 2):
-            rl_seg = [p[idx] for p in rl_parts]
-            ctx_seg = (ctx_parts[:1] if idx < 2 else ctx_parts[1:2]) if ctx_parts else []
-            segs = rl_seg + ctx_seg
-            if rl_seg:
-                segs[0] = f"{C['label']}Limit:{C['reset']} {segs[0]}"
-            if idx == 2 or vlen(" | ".join(segs)) <= W:
-                line2 = segs
+        # 三档收窄；最后一档仍放不下时，丢掉按模型的额度段（5h / 7d / Ctx 优先保住）
+        for idx, drop_quota in ((0, False), (1, False), (2, False), (2, True)):
+            kept = [p for p in rl_parts if not (drop_quota and p[2])]
+            segs = [(tiers[idx], grouped) for tiers, grouped, _ in kept]
+            if ctx_parts:
+                segs.append((ctx_parts[0] if idx < 2 else ctx_parts[1], False))
+            if kept and segs:
+                segs[0] = (f"{C['label']}Limit:{C['reset']} {segs[0][0]}", segs[0][1])
+            joined = _join_limit_segs(segs)
+            if drop_quota or vlen(joined) <= W:
+                line2 = [joined] if joined else []
                 break
 
     # --- Line 3: Tokens（上下文窗口 in/out/cache 构成，非会话累计）| TPS ---

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import time
 import tomllib
+from datetime import UTC, datetime
 
 import pytest
 
@@ -1601,3 +1602,152 @@ def test_ask_components_kimi_question(monkeypatch):
     assert asked[0][0].startswith("[1] ")
     assert c.kimi_statusline is False
     assert c.cc_statusline is True and c.codex_faux_statusline is True
+
+
+def _load_cc_statusline(tmp_path, name):
+    """把模板烘焙成脚本并作为独立模块载入（同 PR #20 两个用例的做法）。"""
+    import importlib.util
+    script = tmp_path / f"{name}.py"
+    script.write_text(hooks._render_hook_script(), encoding="utf-8")
+    spec = importlib.util.spec_from_file_location(f"_tt_scoped_{name}", script)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _limit_line(mod, data, now):
+    """跑一次 render，取出 Limit 行（保留 ANSI 与分隔线，只按去色文本定位）。"""
+    import contextlib
+    import io
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        mod.render(data, now)
+    for line in buf.getvalue().splitlines():
+        if mod.ANSI_RE.sub("", line).startswith("Limit:"):
+            return line
+    return ""
+
+
+def _write_cc_cache(config_dir, percent, resets_at, fetched_at_ms):
+    """伪造 Claude Code 的 /api/oauth/usage 缓存（<config dir>/.claude.json）。"""
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / ".claude.json").write_text(json.dumps({
+        "cachedUsageUtilization": {
+            "fetchedAtMs": fetched_at_ms,
+            "utilization": {"limits": [
+                {"kind": "session", "percent": 5, "scope": None},
+                {"kind": "weekly_all", "percent": 20, "scope": None},
+                {"kind": "weekly_scoped", "percent": percent, "resets_at": resets_at,
+                 "scope": {"model": {"id": None, "display_name": "Fable"}}},
+            ]},
+        }
+    }), encoding="utf-8")
+
+
+def test_scoped_quota_reads_claude_code_cache(tmp_path, monkeypatch):
+    # statusLine 的 payload 里没有按模型的周额度桶（只 spread five_hour/seven_day/spend_limit），
+    # 但 Claude Code 会把 /api/oauth/usage 的响应缓存到 <config dir>/.claude.json。读缓存即可，
+    # 不联网、不碰 OAuth token。config dir 由 transcript_path 逐级上溯定位。
+    mod = _load_cc_statusline(tmp_path, "quota")
+    cfg = tmp_path / ".claude"
+    _write_cc_cache(cfg, 42, "2026-09-08T22:59:59+00:00", 1788908000000)
+    data = {"transcript_path": str(cfg / "projects" / "proj" / "s.jsonl")}
+
+    label, pct, resets_at, stale = mod._scoped_quota(data, 1788908000)
+    assert (label, pct) == ("Fable", 42.0)
+    assert resets_at == int(datetime(2026, 9, 8, 22, 59, 59, tzinfo=UTC).timestamp())
+    assert stale is False
+
+    # fetchedAtMs 超过 1 小时 → 标记为陈旧（渲染时加 "~" 后缀）
+    _write_cc_cache(cfg, 42, "2026-09-08T22:59:59+00:00", 1788908000000 - 3601_000)
+    assert mod._scoped_quota(data, 1788908000)[3] is True
+
+    # 缓存损坏 / 不存在 → None，不抛异常（CC 高频写这个文件，可能读到写了一半）
+    (cfg / ".claude.json").write_text("{broken", encoding="utf-8")
+    assert mod._scoped_quota(data, 1788908000) is None
+
+    # 兜底路径是 ~/.claude —— HOME 必须重定向到空目录，否则用例会读到开发机上真实账号的
+    # 缓存，结果随机器而变（本地首跑就撞上了）
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    assert mod._scoped_quota({"transcript_path": str(tmp_path / "nope" / "s.jsonl")},
+                             1788908000) is None
+
+
+def test_scoped_quota_config_dir_does_not_follow_symlinks(tmp_path, monkeypatch):
+    # projects/ 常被指向共享目录（多账号共用一份 transcript）。若解析 symlink，向上找会走出
+    # config dir 一路到 $HOME，命中旧版本遗留的 ~/.claude.json，读到错误账号的额度。
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    mod = _load_cc_statusline(tmp_path, "symlink")
+    cfg = tmp_path / ".claude-b"
+    _write_cc_cache(cfg, 7, "2026-09-08T22:59:59+00:00", 1788908000000)
+    shared = tmp_path / "shared-projects"
+    (shared / "proj").mkdir(parents=True)
+    link = cfg / "projects"
+    try:
+        link.symlink_to(shared, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("平台不支持创建 symlink")
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    data = {"transcript_path": str(link / "proj" / "s.jsonl")}
+    assert mod._claude_config_dir(data) == str(cfg)
+    assert mod._scoped_quota(data, 1788908000)[1] == 7.0
+
+
+def test_limit_line_groups_scoped_quota_with_seven_day(tmp_path, monkeypatch):
+    # 7d 与按模型的周额度是同一个周窗口：倒计时只打一次（打在后者），两者之间用细线，
+    # 与其余段的粗线形成区隔。没有该额度桶的账号则完全维持原来的 " | "，零视觉变化。
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    mod = _load_cc_statusline(tmp_path, "line2")
+    cfg = tmp_path / ".claude-c"
+    now = datetime(2026, 9, 6, 0, 0, 0, tzinfo=UTC)
+    week_reset = "2026-09-08T22:59:59+00:00"
+    week_epoch = int(datetime(2026, 9, 8, 22, 59, 59, tzinfo=UTC).timestamp())
+    _write_cc_cache(cfg, 42, week_reset, int(now.timestamp() * 1000))
+    monkeypatch.setenv("COLUMNS", "200")
+    data = {
+        "transcript_path": str(cfg / "projects" / "proj" / "s.jsonl"),
+        "workspace": {"current_dir": str(tmp_path)},
+        "rate_limits": {"five_hour": {"used_percentage": 10,
+                                      "resets_at": int(now.timestamp()) + 3600},
+                        "seven_day": {"used_percentage": 20, "resets_at": week_epoch}},
+    }
+    line = _limit_line(mod, data, now)
+    assert "Fable:" in line
+    assert line.count("(") == 2  # 5h 一个倒计时 + 这一对共用的一个，而不是三个
+    assert "│" in line and "┃" in line  # 细线只在 7d 与 Fable 之间
+
+    # 窗口不同 → 各打各的倒计时，也就没有成组，分隔回到普通 " | "
+    data["rate_limits"]["seven_day"]["resets_at"] = week_epoch + 86400
+    line = _limit_line(mod, data, now)
+    assert line.count("(") == 3
+    assert "│" not in line and "┃" not in line
+
+    # 拿不到额度桶 → Limit 行与加此功能前逐字节一致
+    (cfg / ".claude.json").unlink()
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    line = _limit_line(mod, data, now)
+    assert "Fable" not in line and "│" not in line and "┃" not in line
+    assert " | " in line
+
+
+def test_limit_line_drops_scoped_quota_on_narrow_terminal(tmp_path, monkeypatch):
+    # 窄终端优先保住 5h / 7d / Ctx：三档收窄后仍放不下就丢掉按模型的额度段。
+    monkeypatch.setenv("HOME", str(tmp_path / "empty-home"))
+    mod = _load_cc_statusline(tmp_path, "narrow")
+    cfg = tmp_path / ".claude-d"
+    now = datetime(2026, 9, 6, 0, 0, 0, tzinfo=UTC)
+    _write_cc_cache(cfg, 42, "2026-09-08T22:59:59+00:00", int(now.timestamp() * 1000))
+    data = {
+        "transcript_path": str(cfg / "projects" / "proj" / "s.jsonl"),
+        "workspace": {"current_dir": str(tmp_path)},
+        "rate_limits": {"five_hour": {"used_percentage": 10},
+                        "seven_day": {"used_percentage": 20}},
+        "context_window": {"used_percentage": 30, "context_window_size": 200000},
+    }
+    monkeypatch.setenv("COLUMNS", "200")
+    assert "Fable" in _limit_line(mod, data, now)
+    monkeypatch.setenv("COLUMNS", "40")
+    narrow = _limit_line(mod, data, now)
+    assert "Fable" not in narrow
+    assert "5h:" in narrow and "7d:" in narrow


### PR DESCRIPTION
## 问题

Claude Code 的 Max 订阅除 5h / 7d 两个总额度外，还有一个**按模型计的周额度桶**（当前是 Fable）。它跑得比总额度快得多，先撞上限的往往是它，但状态栏此前看不到。

本机实测同一账号同一时刻：

| 窗口 | 用量 |
|---|---|
| 7d（全模型） | 12% |
| 7d（Fable） | 26% |

## 为什么不能直接从 payload 里取

statusLine 的 stdin payload 里没有这个桶。Claude Code 构造该 payload 时只 spread `five_hour` / `seven_day` / `spend_limit`（gateway 模式）。这个桶在 Claude Code 内部叫 `seven_day_overage_included`，窗口表里映射的显示名就是 `"Fable limit"`，对应响应头 `anthropic-ratelimit-unified-7d_oi-utilization`——但响应头外部脚本拿不到。

可用的口子是 `/usage` 面板的数据源 `GET /api/oauth/usage`。**而 Claude Code 会把整个响应缓存到 `<config dir>/.claude.json` 的 `cachedUsageUtilization`**，所以本 PR 直接读这份缓存：

- 不联网，不接触 OAuth token
- 只读不写（`.claude.json` 是 Claude Code 高频写入的文件）
- 60 KB 文件解析约 0.2 ms，渲染耗时无变化

条目形如：

```json
{"kind": "weekly_scoped", "group": "weekly", "percent": 26,
 "resets_at": "2026-09-08T22:59:59+00:00",
 "scope": {"model": {"id": null, "display_name": "Fable"}}, "is_active": true}
```

标签取条目自带的 `display_name`，不看当前选中的模型——这个额度无论用什么模型都在消耗，切到 Opus/Sonnet 时仍需常驻显示。

## 效果

```
Limit: 5h:██░░░░░░ 19% ┃ 7d:█░░░░░░░ 12% │ Fable:██░░░░░░ 26% (1d13h) ┃ 1.0M Ctx:█░░░░░░░ 12%
```

## 几个设计取舍

**重置时间去重**。7d 与这个桶是同一个周窗口，`resets_at` 完全相同，打两遍纯属噪音，只在这一对的后者上打一次。两者相差超过 120 秒时各打各的。

**分隔线分粗细**。加了这一段后 Limit 行有了「7d 与 Fable 同属一个周窗口」的层次，全用 `|` 会读成四个并列项。故成对的两段之间用细线 `│`，其余用粗线 `┃`。**只有真的出现成组段时才升级**——拿不到该额度桶的账号（多数 Pro 用户），Limit 行输出与本 PR 之前逐字节一致，已在测试里断言。两种分隔线的可见宽度都是 3 列，与旧的 `" | "` 相同，窄终端收窄判断无回归。

**陈旧标记**。该缓存的刷新时机是启动预取 / 打开 `/usage` / 撞上限检查，长会话里不开 `/usage` 会一直旧。超过 1 小时（与 Claude Code 自己判定该缓存的阈值一致）在百分数后加 `~`。

**窄终端**。原有三档收窄之后再加一档：仍放不下就丢掉这一段，优先保住 5h / 7d / Ctx，此时分隔线也自动退回 `|`。

**不解析 symlink**。config dir 由 `transcript_path` 逐级上溯定位。开发中踩到过：`projects/` 可能被指向共享目录（多账号共用一份 transcript），`resolve()` 之后会走出 config dir 一路上溯到 `$HOME`，命中旧版本 Claude Code 遗留的 `~/.claude.json`，读到错误账号的数值。测试里有一个专门的 symlink 用例钉住这个行为。

## 健壮性

缓存不存在 / 损坏 / 无该桶 → 静默略过，不影响 Limit 行其余部分。`.claude.json` 可能被读到写了一半，故读取包在 `try/except` 里。

## 测试

新增 4 个用例（`tests/test_hooks.py`）：缓存读取与陈旧判定、symlink 不被解析、成组与去重及无额度时的零变化、窄终端丢弃。

本地按 CI 的步骤跑过：`compileall`、包导入、`pytest`（全绿）、`pytest` 在 `zh_CN.UTF-8` + `TERM=dumb` 下重跑（全绿）、`ruff check src tests` 干净。

> 一个提醒：新增用例里 `~/.claude` 是兜底路径，必须重定向 `HOME` 才能隔离，否则会读到开发机上真实账号的缓存、结果随机器而变。本地首跑就撞上了，已在用例里钉死 `HOME`。

## 未做

`adapters/rate_limits.py` 的 `RateLimits` 与 `tt status` / sidebar 没有动，保持本 PR 聚焦在状态栏。若你觉得那边也该有，我可以另开一个 PR。

`┃` / `│` 若担心某些终端字体缺字，可以换成别的记号，告诉我改法即可。
